### PR TITLE
Add LicenseFinder and list of permissible licenses

### DIFF
--- a/.github/workflows/licensing.yml
+++ b/.github/workflows/licensing.yml
@@ -1,0 +1,22 @@
+name: Verify dependency licenses
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  licensing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: sudo gem install license_finder
+      - run: composer install && npm install
+      - run: license_finder

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,0 +1,37 @@
+---
+- - :permit
+  - MIT
+  - :who:
+    :why:
+    :versions: []
+    :when: 2022-02-17 23:53:13.684525000 Z
+- - :permit
+  - apache-2.0
+  - :who:
+    :why:
+    :versions: []
+    :when: 2022-02-17 23:54:18.454480000 Z
+- - :permit
+  - mpl-2.0
+  - :who:
+    :why:
+    :versions: []
+    :when: 2022-02-17 23:54:42.235980000 Z
+- - :permit
+  - isc
+  - :who:
+    :why:
+    :versions: []
+    :when: 2022-02-17 23:54:44.399263000 Z
+- - :permit
+  - bsd-3-clause
+  - :who:
+    :why:
+    :versions: []
+    :when: 2022-02-17 23:55:08.911817000 Z
+- - :permit
+  - bsd-2-clause
+  - :who:
+    :why:
+    :versions: []
+    :when: 2022-02-17 23:55:10.874938000 Z


### PR DESCRIPTION
This adds LicenseFinder in an action and runs it (along with `composer` and `npm`) to check the dependency licenses.