### PR TITLE
docs(readme): clarify Vitess/MySQL vs Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-> **Note:** This project targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** This project targets PlanetScale Vitess/MySQL. PlanetScale also offers managed Postgres. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 This is the final repo for the Laravel MySQL Mood Tracker project showing PlanetScale integration. You can find the [full tutorial on the PlanetScale blog](https://planetscale.com/blog/build-laravel-crud-mysql-app).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Overview
 
+> **Note:** This project uses `DB_CONNECTION=mysql` and targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+
 This is the final repo for the Laravel MySQL Mood Tracker project showing PlanetScale integration. You can find the [full tutorial on the PlanetScale blog](https://planetscale.com/blog/build-laravel-crud-mysql-app).
 
 <img width="1178" alt="mood-tracker" src="https://user-images.githubusercontent.com/2941081/153310727-a4e8684c-d260-4543-969f-fca489a39a58.png">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-> **Note:** This project uses `DB_CONNECTION=mysql` and targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** This project targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 This is the final repo for the Laravel MySQL Mood Tracker project showing PlanetScale integration. You can find the [full tutorial on the PlanetScale blog](https://planetscale.com/blog/build-laravel-crud-mysql-app).
 


### PR DESCRIPTION
## Summary

- README: clarify that this repository targets PlanetScale Vitess/MySQL (or the MySQL tooling shown in the repo), not PlanetScale-only-MySQL.
- Link readers to Postgres documentation at https://planetscale.com/docs/postgres for managed PostgreSQL databases.

PlanetScale offers both MySQL-compatible (Vitess) and PostgreSQL products.

Made with [Cursor](https://cursor.com)